### PR TITLE
Get the latest version from Scotch, and fix incorrect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Node provides the RESTful API. Angular provides the frontend and accesses the AP
 This repo corresponds to the Node Todo Tutorial Series on [scotch.io](http://scotch.io)
 
 Each branch represents a certain tutorial.
-- tut1-starter: [Creating a Single Page Todo App with Node and Angular](http://scotch.io/tutorials/javascript/creating-a-single-page-todo-app-with-node-and-angular)
+- tut1-starter: [Creating a Single Page Todo App with Node and Angular](https://scotch.io/tutorials/creating-a-single-page-todo-app-with-node-and-angular)
 - tut2-organization: [Application Organization and Structure](https://scotch.io/tutorials/node-and-angular-to-do-app-application-organization-and-structure)
 - tut3-services: [Controllers and Services](https://scotch.io/tutorials/node-and-angular-to-do-app-controllers-and-services)
 

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,35 @@
+###### Spanish Translation
+
+El siguiente codigo construye una app con MongoDB y Angular. Simplemente a modo de ejemplo y como un tutorial.
+
+Node, tecnologia de base en esta app, proveera la API RESTful. Angula proveera el frontendd y el acceso a la API y sus recursos.
+
+MongoDB sera nuestra base de datos. 
+
+## Requerimientos
+- [Node and npm](http://nodejs.org)
+- MongoDB: Asegurate de tener tu instancia de MonboDB configurada correctamente en `config/databases.js`
+
+## Instalacion
+
+
+1. Clonar el repositorio: `git clone git@github.com:scotch-io/node-todo`
+2. Instalar la app: `npm install`
+3. Configurar su base de datos en `config/database.js`
+3. Inicie el servidor: `node server.js`
+4. Con su navegador, dirijase a `http://localhost:8080`
+
+## Series de tutoriales que pueden ser interesantes o estar relacionados
+
+Este tutorial es parte de una serie de tutoriales en  [scotch.io](http://scotch.io)
+
+Cada branch representa un tutorial determinado.
+- tut1-starter: [Crear una Single Page Ap con Node y Angular](http://scotch.io/tutorials/javascript/creating-a-single-page-todo-app-with-node-and-angular)
+- tut2-organization: [Organizacoin de la APP y su esructure](https://scotch.io/tutorials/node-and-angular-to-do-app-application-organization-and-structure)
+- tut3-services: [Controllers and Services](https://scotch.io/tutorials/node-and-angular-to-do-app-controllers-and-services)
+
+A divertirse :)
+
+![Todo-aholic](http://i.imgur.com/ikyqgrn.png)
+
+

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,4 +1,5 @@
 var Todo = require('./models/todo');
+var path = require('path');
 
 function getTodos(res) {
     Todo.find(function (err, todos) {
@@ -52,6 +53,7 @@ module.exports = function (app) {
 
     // application -------------------------------------------------------------
     app.get('*', function (req, res) {
-        res.sendFile(__dirname + '/public/index.html'); // load the single view file (angular will handle the page changes on the front-end)
+        var indexPath = path.resolve(__dirname, '../public/index.html');
+        res.sendFile(indexPath); // load the single view file (angular will handle the page changes on the front-end)
     });
 };

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "body-parser": "^1.4.3",
-    "express": "^4.13.4",
-    "method-override": "^2.1.3",
-    "mongoose": "^4.4.12",
-    "morgan": "^1.1.1"
+    "body-parser": "^1.18.2",
+    "mongoose": "4.10.8",
+    "express": "^4.10.8",
+    "method-override": "^2.3.10",
+    "morgan": "^1.9.0"
   }
 }


### PR DESCRIPTION
This PR merges the upstream source at [scotch-io/node-todo](https://github.com/scotch-io/node-todo) and fixes an incorrect path.

Both changes get rid of errors in the logs of the Node.js process. The main motivation to get rid of these errors now is that we are changing our getting started guide to use the nodejs blueprint, which boots this node-todo app. One of the steps in the new guide is to check the logs of the Node container.